### PR TITLE
Update main.css

### DIFF
--- a/main.css
+++ b/main.css
@@ -609,6 +609,12 @@ h2{
 .fact-card{
     padding: 1em;
 }
+
+/* currentTheme */
+#currentTheme{
+  font-size: 10px;
+}
+
 /*dark theme*/
 .dark-theme{
     background-color: #2B2B2B;


### PR DESCRIPTION
'Back to light mode' button had text (mode) that dropped off onto the next line.  CSS added on line 615 to reduce the size of the button text.